### PR TITLE
Rebuild the dockerhub registry and host it on quay to avoid Jenkins blocks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 
 TARGETS := build deploy new help
 .PHONY: $(TARGETS)
+.DEFAULT_GOAL := help
 
 build: ## Build all containers.
 	@PWD=$(PWD) PUSH=false ./hack/build_and_push.sh

--- a/docker-registry/.dockerignore
+++ b/docker-registry/.dockerignore
@@ -1,0 +1,2 @@
+commands.sh
+registry-v2.tar.gz

--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry:2
+
+LABEL description="Mirror of the dockerhub v2 registry to be hosted on quay. Uses a locally saved version of the image to bypass Jenkins dockerhub restrictions."

--- a/docker-registry/commands.sh
+++ b/docker-registry/commands.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export REPO="quay.io/mtsre"
+export IMAGE="registry"
+export TAG="v2"
+
+# command that will be used to build your container
+function build() {
+    # Bypass Jenkins dockerhub block by loading the image from tar.gz and
+    # populating the local cache
+    docker load <registry-v2.tar.gz
+    docker build \
+        -t "${REPO}/${IMAGE}:${TAG}" .
+}
+
+# command that will be used to push your container
+function push() {
+    docker push "${REPO}/${IMAGE}:${TAG}"
+}

--- a/hack/build_and_push.sh
+++ b/hack/build_and_push.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-PUSH=false
+PUSH=${PUSH:-false}
 
 for container_dir in $(find ${PWD} -type d); do
     # ignore non-compliant container_dir


### PR DESCRIPTION
## Description

Save the registry from dockerhub, and manually populate the docker cache to simply rebuild and tag the image for quay. This is needed because Jenkins blocks pulling images from dockerhub.

Also include a few fixes to the building tools, mainly `PUSH` was always set to false.

## More info

The registry will be used in `py-mtcli` when testing index + bundle images locally. It will replace this registry, which falls short on a few points, and is hard to work with: https://github.com/mt-sre/managed-tenants-cli/blob/main/managedtenants/bundles/registry.py#L34