### PR TITLE
Add docker login to fix docker push.

### DIFF
--- a/hack/build_and_push.sh
+++ b/hack/build_and_push.sh
@@ -2,7 +2,20 @@
 
 set -euo pipefail
 
+# Currently only supports the quay.io/mtsre repository using the `mtsre+push` robot account credentials.
+# You can extend this configuration by modifying the secret injected by Jenkins in app-interface:
+# https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/jenkins/mt-sre/ci-ext/
+function login() {
+    docker --config "${DOCKER_CONF}" login quay.io/mtsre
+}
+
+###
+### Runtime
+###
+
 PUSH=${PUSH:-false}
+
+[[ "${PUSH}" == "true" ]] && login
 
 for container_dir in $(find ${PWD} -type d); do
     # ignore non-compliant container_dir
@@ -15,7 +28,7 @@ for container_dir in $(find ${PWD} -type d); do
 
     echo "Building ${container_dir}..."
     source commands.sh && build
-    [[ "${PUSH}" == true ]] && push
+    [[ "${PUSH}" == "true" ]] && push
 
     # Go back to old directory
     popd >/dev/null


### PR DESCRIPTION
Otherwise we get CI errors.

Tested locally using my own user and got a repro if I `docker logout` then try to push.