### PR TITLE
Try DOCKER_CONFIG env var to fix docker push.

### DIFF
--- a/hack/build_and_push.sh
+++ b/hack/build_and_push.sh
@@ -2,20 +2,14 @@
 
 set -euo pipefail
 
+PUSH=${PUSH:-false}
+
 # Currently only supports the quay.io/mtsre repository using the `mtsre+push` robot account credentials.
 # You can extend this configuration by modifying the secret injected by Jenkins in app-interface:
 # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/jenkins/mt-sre/ci-ext/
-function login() {
-    docker --config "${DOCKER_CONF}" login quay.io/mtsre
-}
-
-###
-### Runtime
-###
-
-PUSH=${PUSH:-false}
-
-[[ "${PUSH}" == "true" ]] && login
+# ---
+# https://docs.docker.com/engine/reference/commandline/cli/#change-the-docker-directory
+[[ "${PUSH}" == "true" ]] && export DOCKER_CONFIG="${DOCKER_CONF}"
 
 for container_dir in $(find ${PWD} -type d); do
     # ignore non-compliant container_dir


### PR DESCRIPTION
## Description
I am lost for an answer here. Login works in CI but yet the push failed. I used the `mtsre+push` creds from Vault locally and was able to push after a login.

Trying this other alternative which also works locally.

Any other ideas?
cc @Ajpantuso 

## CI error log
```bash
10:25:56 + export DOCKER_CONF=/srv/volume/jenkins/workspace/mt-sre-containers-gh-build-main/.docker
10:25:56 + DOCKER_CONF=/srv/volume/jenkins/workspace/mt-sre-containers-gh-build-main/.docker
10:25:56 + mkdir -p /srv/volume/jenkins/workspace/mt-sre-containers-gh-build-main/.docker
10:25:56 + echo ****
10:25:56 + base64 -d
10:25:56 + ./build_deploy.sh
10:25:56 Authenticating with existing credentials...
10:25:56 WARNING! Your password will be stored unencrypted in /srv/volume/jenkins/workspace/mt-sre-containers-gh-build-main/.docker/config.json.
10:25:56 Configure a credential helper to remove this warning. See
10:25:56 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
10:25:56 
10:25:56 Login Succeeded
10:25:56 Building /srv/volume/jenkins/workspace/mt-sre-containers-gh-build-main/docker-registry...
10:25:56 Loaded image: registry:2
10:25:56 Sending build context to Docker daemon  3.072kB

10:25:56 Step 1/2 : FROM registry:2
10:25:56  ---> 2e200967d166
10:25:56 Step 2/2 : LABEL description="Mirror of the dockerhub v2 registry to be hosted on quay. Uses a locally saved version of the image to bypass Jenkins dockerhub restrictions."
10:25:56  ---> Using cache
10:25:56  ---> 7f099156dc34
10:25:56 Successfully built 7f099156dc34
10:25:56 Successfully tagged quay.io/mtsre/registry:v2
10:25:56 The push refers to repository [quay.io/mtsre/registry]
10:25:56 8bb4e6af097f: Preparing
10:25:56 9340e9d17d33: Preparing
10:25:56 9a5e562a5036: Preparing
10:25:56 09e3373b9d9a: Preparing
10:25:56 4fc242d58285: Preparing
10:25:56 09e3373b9d9a: Layer already exists
10:25:56 9340e9d17d33: Layer already exists
10:25:56 9a5e562a5036: Layer already exists
10:25:56 8bb4e6af097f: Layer already exists
10:25:56 4fc242d58285: Layer already exists
10:25:56 unauthorized: access to the requested resource is not authorized
10:25:56 make: *** [deploy] Error 1
10:25:56 Build step 'Execute shell' marked build as failure
10:25:56 Finished: FAILURE
```