### PR TITLE
fix: bumping validate-imageset base to ubi9

### DIFF
--- a/validate-imageset/Dockerfile
+++ b/validate-imageset/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi9/python-39
 
 RUN pip install managedtenants-cli==1.27.0
 


### PR DESCRIPTION
### Summary

Bumping base image for `validate-imageset` to `ubi9` as the EOL message for `ubi8` is already posted on the RedHat Catalog.