### PR TITLE
[MTSRE-796] Add-on installation broken for openshift 4.12: RHODS

### DIFF
--- a/opm-ubi/commands.sh
+++ b/opm-ubi/commands.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export OPM_VERSION="v1.19.5"
+export OPM_VERSION="v1.24.0"
 export BASE_IMAGE="quay.io/app-sre/ubi8-ubi:8.6"
 export REPO="quay.io/mtsre"
 export IMAGE="opm-ubi"


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Updated opm version for broken addon installations on rosa 4.12 clusters.