### PR TITLE
bump py-mtcli version to v1.50.0

### DIFF
--- a/validate-imageset/commands.sh
+++ b/validate-imageset/commands.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PY_MTCLI_VERSION="1.27.0"
+export PY_MTCLI_VERSION="1.50.0"
 export REPO="quay.io/mtsre"
 export IMAGE="validate-imageset"
 


### PR DESCRIPTION
to be merged after this [PR](https://github.com/mt-sre/managed-tenants-cli/pull/393) is merged and the new version is released.